### PR TITLE
OIDCAuthBackend: query userinfo instead of using id_token fields

### DIFF
--- a/pretix_oidc/auth.py
+++ b/pretix_oidc/auth.py
@@ -116,11 +116,13 @@ class OIDCAuthBackend(BaseAuthBackend):
             authn_method="client_secret_basic",
         )
 
+        userinfo = self.client.do_user_info_request(state=auth_response["state"])
+
         id_token = access_token_response["id_token"]
         user_data = {
-            "uuid": id_token[config.get("oidc", "unique_attribute", fallback="sub")],
-            "email": id_token["email"],
-            "fullname": id_token["name"],
+            "uuid": userinfo[config.get("oidc", "unique_attribute", fallback="sub")],
+            "email": userinfo["email"],
+            "fullname": userinfo["name"],
             "auth_backend": self.identifier,
         }
 


### PR DESCRIPTION
Authelia v4.39.0 has changed how it populates the id_token: https://www.authelia.com/blog/4.39-release-notes/ (“ID Token Changes”)

Attributes like "name" or "email" are no longer present in id_token, and should be fetched via userinfo in any case, see also the pyoidc docs: https://pyoidc.readthedocs.io/en/latest/examples/rp.html

This change fixes logging into pretix with Authelia ≥ v4.39.0.