### PR TITLE
Cache Backend Object

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,6 +47,8 @@ __pycache__/
 # C extensions
 *.so
 
+.idea/
+
 # Distribution / packaging
 .Python
 env/

--- a/README.md
+++ b/README.md
@@ -19,9 +19,14 @@ your `pretix.cfg`. Add the OIDC configuration to that same file in a new
     # label on the login button,
     # default: Login with OpenID connect
     title=
+    # issuer must be set
+    issuer=
+    # all endpoints are normally autodiscovered
+    # autodiscover might be disabled by setting skip_provider_discovery=True
+    skip_provider_discovery=
     # OIDC URIs, can generally be found unter .well-known/openid-configuration
     # of your OIDC endpoint
-    issuer=
+    # to override autodiscovered values or manually seeting them when autodiscover is disabled, set them manually
     authorization_endpoint=
     token_endpoint=
     userinfo_endpoint=

--- a/README.md
+++ b/README.md
@@ -47,6 +47,9 @@ your `pretix.cfg`. Add the OIDC configuration to that same file in a new
     staff_value=
     # multiple staff_values can be provided, separated by commas. whitespaces are ignored.
     # staff_value=val_1,val_2
+    lifetime=
+    # lifetime in seconds of the OIDC backend object including JWKS cache
+    # default: 3600
 
 The callback URI on your pretix will be `/oidc/callback/`, enter this at the
 appropriate place in your OIDC provider.

--- a/pretix_oidc/auth.py
+++ b/pretix_oidc/auth.py
@@ -41,7 +41,7 @@ class OIDCAuthBackend(BaseAuthBackend):
             )
 
             self.client = Client(client_authn_method=CLIENT_AUTHN_METHOD)
-            if config.get("oidc", "skip_provider_discovery", fallback=False):
+            if not config.get("oidc", "skip_provider_discovery", fallback=False):
                 # If skip_provider_discovery is set, we do not fetch the provider config
                 # but use the provided information directly.
                 self.client.provider_config(op_info["issuer"])
@@ -57,7 +57,7 @@ class OIDCAuthBackend(BaseAuthBackend):
             )
             if len(missing_endpoints)>0:
                 logger.error("Please specify " + ", ".join(sorted(missing_endpoints)) + " in [oidc] section in pretix.cfg")
-            if len(self.client.keyjar[op_info["issuer"]]) == 0:
+            if  len(self.client.keyjar.get_issuer_keys(self.client.issuer)) == 0:
                 logger.error(
                     "Please specify jwks_uri in [oidc] section in pretix.cfg or ensure that the issuer supports jwks_uri discovery."
                 )

--- a/pretix_oidc/auth.py
+++ b/pretix_oidc/auth.py
@@ -23,16 +23,16 @@ class OIDCAuthBackend(BaseAuthBackend):
                 "oidc", "title", fallback="Login with OpenID connect"
             )
 
-            # setting config.get to None and ProviderConfigurationResponse handles None as unset we can use this
-            # object as overrides
+            # setting config.get to None and ProviderConfigurationResponse handles empty string as unset we can use this
+            # object as override values
             op_info = ProviderConfigurationResponse(
                 version="1.0",
                 issuer=config.get("oidc", "issuer"),
-                authorization_endpoint=config.get("oidc", "authorization_endpoint", fallback=None),
-                token_endpoint=config.get("oidc", "token_endpoint", fallback=None),
-                userinfo_endpoint=config.get("oidc", "userinfo_endpoint", fallback=None),
-                end_session_endpoint=config.get("oidc", "end_session_endpoint", fallback=None),
-                jwks_uri=config.get("oidc", "jwks_uri", fallback=None),
+                authorization_endpoint=config.get("oidc", "authorization_endpoint", fallback=""),
+                token_endpoint=config.get("oidc", "token_endpoint", fallback=""),
+                userinfo_endpoint=config.get("oidc", "userinfo_endpoint", fallback=""),
+                end_session_endpoint=config.get("oidc", "end_session_endpoint", fallback=""),
+                jwks_uri=config.get("oidc", "jwks_uri", fallback=""),
             )
 
             client_reg = RegistrationResponse(

--- a/pretix_oidc/auth.py
+++ b/pretix_oidc/auth.py
@@ -54,7 +54,7 @@ class OIDCAuthBackend(BaseAuthBackend):
                 "end_session_endpoint",
                 "jwks_uri"
             } - set(
-                {k:v for k,v in self.client.__dict__.items() if k.endswith("_endpoint") and v is not None}.keys()
+                {k:v for k,v in self.client.__dict__.items() if v is not None}.keys()
             )
             if len(missing_endpoints)>0:
                 logger.error("Please specify " + ", ".join(sorted(missing_endpoints)) + " in [oidc] section in pretix.cfg")

--- a/pretix_oidc/auth.py
+++ b/pretix_oidc/auth.py
@@ -45,7 +45,7 @@ class OIDCAuthBackend(BaseAuthBackend):
                 # If skip_provider_discovery is set, we do not fetch the provider config
                 # but use the provided information directly.
                 self.client.provider_config(op_info["issuer"])
-            self.client.provider_config(op_info["issuer"])
+            self.client.handle_provider_config(op_info, op_info["issuer"])
 
             missing_endpoints = {
                 "authorization_endpoint",

--- a/pretix_oidc/auth.py
+++ b/pretix_oidc/auth.py
@@ -51,13 +51,16 @@ class OIDCAuthBackend(BaseAuthBackend):
                 "authorization_endpoint",
                 "token_endpoint",
                 "userinfo_endpoint",
-                "end_session_endpoint",
-                "jwks_uri"
+                "end_session_endpoint"
             } - set(
                 {k:v for k,v in self.client.__dict__.items() if k.endswith("_endpoint") and v is not None}.keys()
             )
             if len(missing_endpoints)>0:
                 logger.error("Please specify " + ", ".join(sorted(missing_endpoints)) + " in [oidc] section in pretix.cfg")
+            if len(self.client.keyjar[op_info["issuer"]]) == 0:
+                logger.error(
+                    "Please specify jwks_uri in [oidc] section in pretix.cfg or ensure that the issuer supports jwks_uri discovery."
+                )
             self.client.handle_provider_config(op_info, op_info["issuer"])
             self.client.store_registration_info(client_reg)
             self.client.redirect_uris = [None]

--- a/pretix_oidc/auth.py
+++ b/pretix_oidc/auth.py
@@ -54,7 +54,7 @@ class OIDCAuthBackend(BaseAuthBackend):
                 "end_session_endpoint",
                 "jwks_uri"
             } - set(
-                {k:v for k,v in self.client.__dict__.items() if v is not None}.keys()
+                {k:v for k,v in self.client.__dict__.items() if k.endswith("_endpoint") and v is not None}.keys()
             )
             if len(missing_endpoints)>0:
                 logger.error("Please specify " + ", ".join(sorted(missing_endpoints)) + " in [oidc] section in pretix.cfg")

--- a/pretix_oidc/auth.py
+++ b/pretix_oidc/auth.py
@@ -341,7 +341,7 @@ def get_auth_backend():
         auth_backend.client.keyjar = None
         logger.info("Storing new auth backend in cache")
         cache.set(CACHE_KEY_BACKEND, auth_backend, auth_backend_lifetime)
-        cache.set(CACHE_KEY_JWKS, auth_backend, auth_backend_lifetime)
+        cache.set(CACHE_KEY_JWKS, jwks, auth_backend_lifetime)
     else:
         logger.info("Using cached auth backend")
         auth_backend.client.keyjar= KeyJar()

--- a/pretix_oidc/auth.py
+++ b/pretix_oidc/auth.py
@@ -153,3 +153,5 @@ class OIDCAuthBackend(BaseAuthBackend):
         }
 
         return [user_data, id_token]
+
+auth_backend = OIDCAuthBackend()

--- a/pretix_oidc/auth.py
+++ b/pretix_oidc/auth.py
@@ -60,6 +60,7 @@ class OIDCAuthBackend(BaseAuthBackend):
             }
             if len(missing_endpoints)>0:
                 logger.error("Please specify " + ", ".join(sorted(missing_endpoints)) + " in [oidc] section in pretix.cfg")
+            # check whether we have at least one key for the issuer
             if  len(self.client.keyjar.get_issuer_keys(self.client.issuer)) == 0:
                 logger.error(
                     "Please specify jwks_uri in [oidc] section in pretix.cfg or ensure that the issuer supports jwks_uri discovery."

--- a/pretix_oidc/auth.py
+++ b/pretix_oidc/auth.py
@@ -329,6 +329,8 @@ def on_user_logged_out(sender, request, user, **kwargs):
         logger.debug(f"Removed OIDCSessions for user logout. user_id={user.id} oidc_sessions_removed={oidc_session_count}.")
 
     def __getstate__(self):
+        logger.info("Serializing OIDCAuthBackend for caching")
+        return {}
         return {
             "op_info": self.op_info,
             "client_reg": self.client_reg,

--- a/pretix_oidc/auth.py
+++ b/pretix_oidc/auth.py
@@ -23,14 +23,16 @@ class OIDCAuthBackend(BaseAuthBackend):
                 "oidc", "title", fallback="Login with OpenID connect"
             )
 
+            # setting config.get to None and ProviderConfigurationResponse handles None as unset we can use this
+            # object as overrides
             op_info = ProviderConfigurationResponse(
                 version="1.0",
                 issuer=config.get("oidc", "issuer"),
-                authorization_endpoint=config.get("oidc", "authorization_endpoint"),
-                token_endpoint=config.get("oidc", "token_endpoint"),
-                userinfo_endpoint=config.get("oidc", "userinfo_endpoint"),
-                end_session_endpoint=config.get("oidc", "end_session_endpoint"),
-                jwks_uri=config.get("oidc", "jwks_uri"),
+                authorization_endpoint=config.get("oidc", "authorization_endpoint", fallback=None),
+                token_endpoint=config.get("oidc", "token_endpoint", fallback=None),
+                userinfo_endpoint=config.get("oidc", "userinfo_endpoint", fallback=None),
+                end_session_endpoint=config.get("oidc", "end_session_endpoint", fallback=None),
+                jwks_uri=config.get("oidc", "jwks_uri", fallback=None),
             )
 
             client_reg = RegistrationResponse(
@@ -39,6 +41,11 @@ class OIDCAuthBackend(BaseAuthBackend):
             )
 
             self.client = Client(client_authn_method=CLIENT_AUTHN_METHOD)
+            if config.get("oidc", "skip_provider_discovery", fallback=False):
+                # If skip_provider_discovery is set, we do not fetch the provider config
+                # but use the provided information directly.
+                self.client.provider_config(op_info["issuer"])
+            self.client.provider_config(op_info["issuer"])
             self.client.handle_provider_config(op_info, op_info["issuer"])
             self.client.store_registration_info(client_reg)
             self.client.redirect_uris = [None]

--- a/pretix_oidc/auth.py
+++ b/pretix_oidc/auth.py
@@ -328,3 +328,4 @@ def get_auth_backend():
     if auth_backend is None:
         auth_backend = OIDCAuthBackend()
         cache.set('pretix_oidc_auth_backend', auth_backend, auth_backend_lifetime)
+    return auth_backend

--- a/pretix_oidc/auth.py
+++ b/pretix_oidc/auth.py
@@ -46,6 +46,18 @@ class OIDCAuthBackend(BaseAuthBackend):
                 # but use the provided information directly.
                 self.client.provider_config(op_info["issuer"])
             self.client.provider_config(op_info["issuer"])
+
+            missing_endpoints = {
+                "authorization_endpoint",
+                "token_endpoint",
+                "userinfo_endpoint",
+                "end_session_endpoint",
+                "jwks_uri"
+            } - set(
+                {k:v for k,v in self.client.__dict__.items() if k.endswith("_endpoint") and v is not None}.keys()
+            )
+            if len(missing_endpoints)>0:
+                logger.error("Please specify " + ", ".join(sorted(missing_endpoints)) + " in [oidc] section in pretix.cfg")
             self.client.handle_provider_config(op_info, op_info["issuer"])
             self.client.store_registration_info(client_reg)
             self.client.redirect_uris = [None]
@@ -53,8 +65,7 @@ class OIDCAuthBackend(BaseAuthBackend):
             self.scopes = config.get("oidc", "scopes", fallback="openid").split(",")
         except (NoSectionError, NoOptionError):
             logger.error(
-                "Please specify issuer, authorization_endpoint, token_endpoint, userinfo_endpoint, end_session_endpoint, jwks_uri, client_id and client_secret "
-                "in [oidc] section in pretix.cfg"
+                "Please specify issuer, client_id and client_secret in [oidc] section in pretix.cfg"
             )
 
     @property

--- a/pretix_oidc/auth.py
+++ b/pretix_oidc/auth.py
@@ -325,7 +325,9 @@ auth_backend_lifetime = config.getint("oidc", "lifetime", fallback=3600)
 
 def get_auth_backend():
     auth_backend = cache.get('pretix_oidc_auth_backend', None)
+    logger.info(auth_backend)
     if auth_backend is None:
         auth_backend = OIDCAuthBackend()
+        logger.info("Storing new auth backend in cache")
         cache.set('pretix_oidc_auth_backend', auth_backend, auth_backend_lifetime)
     return auth_backend

--- a/pretix_oidc/auth.py
+++ b/pretix_oidc/auth.py
@@ -52,9 +52,12 @@ class OIDCAuthBackend(BaseAuthBackend):
                 "token_endpoint",
                 "userinfo_endpoint",
                 "end_session_endpoint"
-            } - set(
-                {k:v for k,v in self.client.__dict__.items() if k.endswith("_endpoint") and v is not None}.keys()
-            )
+            } - {
+                k
+                for k,v
+                in self.client.__dict__.items()
+                if k.endswith("_endpoint") and v is not None
+            }
             if len(missing_endpoints)>0:
                 logger.error("Please specify " + ", ".join(sorted(missing_endpoints)) + " in [oidc] section in pretix.cfg")
             if  len(self.client.keyjar.get_issuer_keys(self.client.issuer)) == 0:

--- a/pretix_oidc/migrations/0003_oidc_backchannel_logout.py
+++ b/pretix_oidc/migrations/0003_oidc_backchannel_logout.py
@@ -1,0 +1,35 @@
+import django.db.models.deletion
+from django.db import migrations, models
+
+class Migration(migrations.Migration):
+    initial = True
+
+    dependencies = [
+        ("pretix_oidc", "0002_auto_20200919_2030"),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name="OIDCSession",
+            fields=[
+                (
+                    "user",
+                    models.ForeignKey(
+                        on_delete=django.db.models.deletion.CASCADE,
+                        to="pretixbase.User",
+                    ),
+                ),
+                ("session_id", models.CharField(max_length=255, db_index=True)),
+                ("oidc_session_id", models.CharField(max_length=255, db_index=True)),
+                ("oidc_user_id", models.CharField(max_length=255, db_index=True)),
+                ("oidc_issuer", models.CharField(max_length=255, db_index=True)),
+                ("created_at", models.DateTimeField(auto_now_add=True, db_index=True)),
+            ],
+            options={
+                "indexes": [
+                    models.Index(fields=["oidc_issuer", "oidc_user_id"], name="oidc_issuer_user_idx"),
+                    models.Index(fields=["oidc_issuer", "oidc_session_id"], name="oidc_issuer_sess_idx"),
+                ],
+            },
+        ),
+    ]

--- a/pretix_oidc/models.py
+++ b/pretix_oidc/models.py
@@ -1,6 +1,6 @@
 from django.db import models
 from django.utils.translation import gettext_lazy
-from pretix.base.models import Team
+from pretix.base.models import Team, User
 
 
 class OIDCTeamAssignmentRule(models.Model):
@@ -19,3 +19,21 @@ class OIDCTeamAssignmentRule(models.Model):
             )
         ]
         verbose_name = gettext_lazy("Team assignment rule")
+
+class OIDCSession(models.Model):
+    """
+    Persisted mapping between Django sessions and OIDC sessions.
+
+    Augments the Django session with OIDC-specific identifiers
+    (issuer, subject, session ID) to enable efficient session lookup and
+    cleanup during OIDC back-channel logout.
+    """
+    # django user id -> lookup by django user id
+    user = models.ForeignKey(User, on_delete=models.CASCADE)
+    # django session id -> lookup by django session
+    session_id = models.CharField(max_length=255)
+    # django user id -> lookup by user_session_id
+    oidc_session_id = models.CharField(max_length=255)
+    oidc_user_id = models.CharField(max_length=255)
+    oidc_issuer = models.CharField(max_length=255)
+    created_at = models.DateTimeField(auto_now_add=True)

--- a/pretix_oidc/urls.py
+++ b/pretix_oidc/urls.py
@@ -4,6 +4,7 @@ from . import views
 
 urlpatterns = [
     path("oidc/callback/", views.oidc_callback, name="oidc_callback"),
+    path("oidc/backchannel_logout/", views.oidc_backchannel_logout, name="oidc_backchannel_logout"),
     path(
         "control/organizer/<str:organizer>/teams/assignment_rules/",
         views.AssignmentRulesList.as_view(),

--- a/pretix_oidc/views.py
+++ b/pretix_oidc/views.py
@@ -16,12 +16,13 @@ from pretix.control.views.auth import process_login
 from pretix.helpers.compat import CompatDeleteView
 from pretix.settings import config
 
-from .auth import auth_backend  # NOQA
+from .auth import get_auth_backend
 from .forms import OIDCAssignmentRuleForm
 from .models import OIDCTeamAssignmentRule
 
 
 def oidc_callback(request):
+    auth_backend = get_auth_backend()
     user_data, id_token = auth_backend.process_callback(request)
 
     if user_data is None:
@@ -98,7 +99,7 @@ def oidc_backchannel_logout(request):
 
     See: https://openid.net/specs/openid-connect-backchannel-1_0.html
     """
-    logout_response = auth_backend.process_backchannel_logout(request)
+    logout_response = get_auth_backend().process_backchannel_logout(request)
     if logout_response.get("status") == "logout_error":
         return JsonResponse(data=logout_response, status=400)
 

--- a/pretix_oidc/views.py
+++ b/pretix_oidc/views.py
@@ -1,9 +1,12 @@
 from dictlib import dig_get
 from django.contrib import messages
 from django.core.exceptions import ObjectDoesNotExist
+from django.http import JsonResponse
 from django.shortcuts import redirect
 from django.urls import reverse
 from django.utils.translation import gettext as _
+from django.views.decorators.csrf import csrf_exempt
+from django.views.decorators.http import require_POST
 from django.views.generic import TemplateView
 from django.views.generic.edit import CreateView
 from pretix.base.models import Team, User
@@ -44,7 +47,10 @@ def oidc_callback(request):
     else:
         _add_user_to_teams(user, id_token)
         _add_user_to_staff(user, id_token)
-        return process_login(request, user, False)
+        response = process_login(request, user, False)
+        # after process_login we can use the real session key
+        auth_backend.store_oidc_session(request.session.session_key, user, id_token)
+        return response
 
 
 def _add_user_to_teams(user, id_token):
@@ -81,6 +87,22 @@ def _get_attr(id_token, attr_name):
         values = [values]
     return values
 
+@csrf_exempt
+@require_POST
+def oidc_backchannel_logout(request):
+    """
+    Handle OIDC back-channel logout requests.
+
+    Processes a POST request from an OpenID Connect provider to terminate
+    user sessions associated with an OIDC logout event.
+
+    See: https://openid.net/specs/openid-connect-backchannel-1_0.html
+    """
+    logout_response = auth_backend.process_backchannel_logout(request)
+    if logout_response.get("status") == "logout_error":
+        return JsonResponse(data=logout_response, status=400)
+
+    return JsonResponse(data=logout_response, status=200)
 
 # These views have been adapted from pretix-cas plugin (https://github.com/DataManagementLab/pretix-cas)
 class AssignmentRulesList(TemplateView, OrganizerPermissionRequiredMixin):

--- a/pretix_oidc/views.py
+++ b/pretix_oidc/views.py
@@ -13,13 +13,12 @@ from pretix.control.views.auth import process_login
 from pretix.helpers.compat import CompatDeleteView
 from pretix.settings import config
 
-from .auth import OIDCAuthBackend  # NOQA
+from .auth import auth_backend  # NOQA
 from .forms import OIDCAssignmentRuleForm
 from .models import OIDCTeamAssignmentRule
 
 
 def oidc_callback(request):
-    auth_backend = OIDCAuthBackend()
     user_data, id_token = auth_backend.process_callback(request)
 
     if user_data is None:


### PR DESCRIPTION
Please merge #14 before

This implements caching of the backend object achieving two goals:

1. Discovery and JWKS retrieval is only run on one server and shared across servers
2. Due to a set cache timeout the JWKS store is refreshed periodically